### PR TITLE
Update new sheet compatibility script to work for Foundry 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Patch Notes
 
+## Version 1.10.1
+
+- Update for V12. Fixes sheets not opening on Foundry V12.
+
 ## Version 1.10.0
 
 - Update for dnd5e v3+

--- a/compat/newSheetCompat.js
+++ b/compat/newSheetCompat.js
@@ -15,7 +15,7 @@ export function newSheetCompat() {
     if (path != "systems/dnd5e/templates/actors/character-sheet-2.hbs")
       return origGetTemplate(path, id, ...misc);
 
-    if ( !_templateCache.hasOwnProperty(path) ) {
+    if ( !Handlebars.partials.hasOwnProperty(path) ) {
       await new Promise((resolve, reject) => {
         game.socket.emit("template", path, resp => {
           if (resp.error) return reject(new Error(resp.error));
@@ -78,13 +78,13 @@ export function newSheetCompat() {
 
           const compiled = Handlebars.compile(resp.html);
           Handlebars.registerPartial(id ?? path, compiled);
-          _templateCache[path] = compiled;
+          Handlebars.partials[path] = compiled;
           console.log(`Foundry VTT | Retrieved and compiled template ${path}`);
           resolve(compiled);
         });
       });
     }
-    return _templateCache[path];
+    return Handlebars.partials[path];
 }
 
   initialized = true;

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "title": "5e-Sheet Resources Plus",
   "description": "A module that allows you to add more resources to character sheets",
   "url": "https://github.com/ardittristan/5eSheet-resourcesPlus/tree/master",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "esmodules": [
     "addresources.js"
   ],


### PR DESCRIPTION
Updates `newSheetCompat.js` to use `Handlebars.partials` over `_templateCache` as the latter was recently removed.