### PR TITLE
dnd5e 3.3.x Resource Consumption Dropdown Options Fix

### DIFF
--- a/addresources.js
+++ b/addresources.js
@@ -210,8 +210,11 @@ Hooks.on("init", function () {
     "WRAPPER"
   );
 
-  // Monkeypatch item sheet list so it shows up under the resources for items/spells
-  monkeypatchSheet(itemResources);
+  // Updating CONFIG.DND5E.consumableResources must be done in "setup"
+  Hooks.on("setup", function () {
+    // Monkeypatch item sheet list so it shows up under the resources for items/spells
+    monkeypatchSheet(itemResources);
+  });
 
   newSheetCompat();
 


### PR DESCRIPTION
The Resource Consumption dropdown is not showing in dnd5 3.3.x because the system now initializes `CONFIG.DND5E.consumableResources` during the "setup" phase, and Resources Plus is adding options in the "init" phase.

This fix will ensure that Resources Plus waits for the "setup" phase to begin and for `CONFIG.DND5E.consumableResources` to be populated before adding the other resource options.